### PR TITLE
Add required tox.ini files

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,2 @@
+black
+flake8

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,23 @@
+[tox]
+minversion = 1.4.2
+envlist = linters
+skipsdist = True
+
+[testenv]
+deps = -r{toxinidir}/requirements.txt
+       -r{toxinidir}/test-requirements.txt
+
+[testenv:linters]
+install_command = pip install {opts} {packages}
+commands =
+  black -v -l79 --check {toxinidir}
+  flake8 {posargs}
+
+[flake8]
+# E123, E125 skipped as they are invalid PEP-8.
+
+show-source = True
+ignore = E123,E125,E402,W503
+max-line-length = 160
+builtins = _
+exclude = .git,.tox


### PR DESCRIPTION
This allows us to start running ansible-linters jobs.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>