### PR TITLE
Remove version number from galaxy.yaml

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -6,4 +6,3 @@ name: cli
 namespace: network
 readme: README.rst
 repository: https://github.com/ansible-network/ansible_collections.network.cli
-version: 0.0.1


### PR DESCRIPTION
We dynamically generate our version numbers via git, so we can remove
this to avoid it being out of date.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>